### PR TITLE
solve error

### DIFF
--- a/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
+++ b/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
@@ -345,7 +345,7 @@
               <MiscControls></MiscControls>
               <Define>USE_STDPERIPH_DRIVER,STM32F10X_HD,USE_FULL_ASSERT</Define>
               <Undefine></Undefine>
-              <IncludePath>..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc</IncludePath>
+              <IncludePath>..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc;..\..\..\stm32f4xx\Libraries\CMSIS\Include</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>

--- a/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
+++ b/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
@@ -345,7 +345,7 @@
               <MiscControls></MiscControls>
               <Define>USE_STDPERIPH_DRIVER,STM32F10X_HD,USE_FULL_ASSERT</Define>
               <Undefine></Undefine>
-              <IncludePath>..\Libraries\CMSIS_RVMDK\CM3\CoreSupport;..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc</IncludePath>
+              <IncludePath>..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\CoreSupport;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>

--- a/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
+++ b/demo/stm32f10x/rtt/RVMDK/EasyFlash.uvproj
@@ -345,7 +345,7 @@
               <MiscControls></MiscControls>
               <Define>USE_STDPERIPH_DRIVER,STM32F10X_HD,USE_FULL_ASSERT</Define>
               <Undefine></Undefine>
-              <IncludePath>..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc;..\..\..\stm32f4xx\Libraries\CMSIS\Include</IncludePath>
+              <IncludePath>..\Libraries\CMSIS_RVMDK\CM3\CoreSupport;..\app\inc;..\components\rtt_uart;..\components\others;..\Libraries\STM32F10x_StdPeriph_Driver\inc;..\Libraries\CMSIS_RVMDK\CM3\DeviceSupport\ST\STM32F10x;..\RT-Thread-1.2.2\include;..\RT-Thread-1.2.2\components\drivers\include;..\RT-Thread-1.2.2\components\drivers\include\drivers;..\RT-Thread-1.2.2\components\finsh;..\..\..\..\easyflash\inc</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>


### PR DESCRIPTION
solve Keil V5 error.
include path "..\Libraries\CMSIS_RVMDK\CM3\CoreSupport" for solve error "error:  #5: cannot open source input file "core_cm3.h": No such file or directory"