### PR TITLE
Improve English grammar in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Demo平台：STM32F103RET6 + RT-Thread 1.2.2 + Env(2K bytes)
 
 ## 1 Introduction
 
-[EasyFlash](https://github.com/armink/EasyFlash) is an open source lightweight embedded flash memory library. It provide convenient application interface for MCU (Micro Control Unit). The developers can achieve more efficient and common application development based on Flash memory. The library currently provides **Three useful features** ：
+[EasyFlash](https://github.com/armink/EasyFlash) is an open source lightweight embedded flash memory library. It provides convenient application interface for MCU (Micro Control Unit). The developers can achieve more efficient and common application development based on Flash memory. The library currently provides **three useful features** ：
 
 - **Env(environment variables)** Fast Saves product parameters. Support **write balance mode(wear leveling)** and **power fail safeguard**. 
 
-EasyFlash can be store **setting parameters** or **running logs** and other information which you want to power down to save. And it packaged add, delete, modify and query method. It make developer easy to process the product parameters. And make sure the product has better scalability after upgrade. Let Flash becomes a small NoSQL (non-relational databases) model and Key-Value stores database.
+EasyFlash can store **setting parameters** or **running logs** and other information which you want to keep after power down. It contains add, delete, modify and query methods. It helps developer to process the product parameters, and makes sure the product has better scalability after upgrade. Turns the Flash into a small NoSQL (non-relational databases) model and Key-Value stores database.
 
 - **IAP** : online upgrade is no longer a difficult thing.
  
@@ -97,7 +97,7 @@ Actual  : ROM: 6K bytes     RAM: 2.6K bytes
 
 ### 1.2 Supported platforms
 
-Hardware platform has been ported SPI Flash, `stm32f10x` and `stm32f4xx` series of on-chip Flash. These are my product platforms. Remaining platform porting difficulty is little. The porting just modify [`\easyflash\port\ef_port.c`](https://github.com/armink/EasyFlash/blob/master/easyflash/port/ef_port.c) file. Implement erase, write, read, print feature.
+Hardware platform has been ported SPI Flash, `stm32f10x` and `stm32f4xx` series of on-chip Flash. These are my product platforms. Remaining platform porting difficulty is little. To port it just modify [`\easyflash\port\ef_port.c`](https://github.com/armink/EasyFlash/blob/master/easyflash/port/ef_port.c) file. Implement erase, write, read, print feature.
 
 Welcome everyone to **fork and pull request**([Github](https://github.com/armink/EasyFlash)|[OSChina](http://git.oschina.net/armink/EasyFlash)|[Coding](https://coding.net/u/armink/p/EasyFlash/git)). If you think this open source project is awesome. You can press the **Star** on the top right corner of [project home page](https://github.com/armink/EasyFlash), and recommend it to more friends.
 
@@ -105,7 +105,7 @@ Welcome everyone to **fork and pull request**([Github](https://github.com/armink
 
 ### 2.1 Env(KV database)
 
-The figure below shows an ENV's common interface be called by the console(terminal). These interfaces are supported by the application layer called.
+The figure below shows an ENV's common interface be called by the console (terminal). These interfaces are supported by the application layer called.
 
 - 1.Create temperature environment variable. It's name is `temp` and value is `123`;
 - 2.Save temperature to flash and reboot;
@@ -118,19 +118,19 @@ The figure below shows an ENV's common interface be called by the console(termin
 
 ### 2.2 IAP
 
-The figure below shows the process of upgrade software through the console by IAP. It use this library comes with IAP function interface. Uses a serial port + Ymodem protocol mode. You can also be achieved through CAN, 485, Ethernet bus to online upgrade.
+The figure below shows the process of upgrading software through the console by IAP. It use this library comes with IAP function interface. It uses a serial port + Ymodem protocol mode. You can also be achieved through CAN, 485, Ethernet bus to online upgrade.
 
 ![easy_flash_iap](https://raw.githubusercontent.com/armink/EasyFlash/master/docs/en/images/IapDemo.gif)
 
 ### 2.3 Log
 
-The following figure is the output log process through the console. The logs will save to flash at the same time. Then reboot the and read the logs from flash. At last will clean all logs which on flash.
+The following figure is the output of the log process through the console. The logs are saved to flash at real time. Then the board is rebooted and the logs back are read back from flash. At last logs will be erased.
 
 ![easy_flash_log](https://raw.githubusercontent.com/armink/EasyFlash/master/docs/en/images/LogDemo.gif)
 
 ## 3 Documents
 
-All documents is in the [`\docs\en\`](https://github.com/armink/EasyFlash/tree/master/docs/en) folder. Please **read the documents** before port and use it.
+All documents are in the [`\docs\en\`](https://github.com/armink/EasyFlash/tree/master/docs/en) folder. Please **read the documents** before porting it and using it.
 
 ## 4 License
 

--- a/easyflash/inc/ef_cfg.h
+++ b/easyflash/inc/ef_cfg.h
@@ -59,14 +59,14 @@
  * |(IAP)Downloaded application |   IAP already downloaded application, unfixed size
  * |----------------------------|
  *
- * @note all area size must be aligned with EF_ERASE_MIN_SIZE
- * @note EasyFlash will use ram to buffered the ENV. At some time flash's EF_ERASE_MIN_SIZE is so big,
- *       and you want use ENV size is less than it. So you must defined ENV_USER_SETTING_SIZE for ENV.
+ * @note all area sizes must be aligned with EF_ERASE_MIN_SIZE
+ * @note EasyFlash will use ram to buffer the ENV. At some point flash's EF_ERASE_MIN_SIZE may become so big,
+ *       and you want to keep ENV size smaller. To do it you must define ENV_USER_SETTING_SIZE for ENV.
  * @note ENV area size has some limitations in different modes.
- *       1.Normal mode: no more limitations
- *       2.Wear leveling mode: system section will used an flash section and the data section will used at least 2 flash sections
- *       3.Power fail safeguard mode: ENV area will has an backup. It is twice as normal mode.
- *       4.wear leveling and power fail safeguard mode: The required capacity will be 2 times the total capacity in wear leveling mode.
+ *       1.Normal mode: no limitations
+ *       2.Wear leveling mode: system section will used a flash section and the data section will use at least 2 flash sections
+ *       3.Power fail safeguard mode: ENV area will has a backup. It is twice as normal mode.
+ *       4.Wear leveling and power fail safeguard mode: The required capacity will be 2 times the total capacity in wear leveling mode.
  *       For example:
  *       The EF_ERASE_MIN_SIZE is 128K and the ENV_USER_SETTING_SIZE: 2K. The ENV_AREA_SIZE in different mode you can define
  *       1.Normal mode: 1*EF_ERASE_MIN_SIZE

--- a/easyflash/src/easyflash.c
+++ b/easyflash/src/easyflash.c
@@ -39,16 +39,16 @@
  * |(IAP)Downloaded application |   IAP already downloaded application, unfixed size
  * |----------------------------|
  *
- * @note all area size must be aligned with EF_ERASE_MIN_SIZE
- * @note EasyFlash will use ram to buffered the ENV. At some time flash's EF_ERASE_MIN_SIZE is so big,
- *       and you want use ENV size is less than it. So you must defined ENV_USER_SETTING_SIZE for ENV.
+ * @note all area sizes must be aligned with EF_ERASE_MIN_SIZE
+ * @note EasyFlash will use ram to buffer the ENV. At some point flash's EF_ERASE_MIN_SIZE may become too large,
+ *       and if you want to use an smaller ENV size, you must define ENV_USER_SETTING_SIZE for ENV.
  * @note ENV area size has some limitations in different modes.
- *       1.Normal mode: no more limitations
- *       2.Wear leveling mode: system section will used an flash section and the data section will used at least 2 flash sections
- *       3.Power fail safeguard mode: ENV area will has an backup. It is twice as normal mode.
+ *       1.Normal mode: no limitations
+ *       2.Wear leveling mode: system section will use an entire flash section and the data section will use at least 2 flash sections
+ *       3.Power fail safeguard mode: ENV area will keep a backup. It is twice the size of normal mode.
  *       4.wear leveling and power fail safeguard mode: The required capacity will be 2 times the total capacity in wear leveling mode.
  *       For example:
- *       The EF_ERASE_MIN_SIZE is 128K and the ENV_USER_SETTING_SIZE: 2K. The ENV_AREA_SIZE in different mode you can define
+ *       The EF_ERASE_MIN_SIZE is 128K and the ENV_USER_SETTING_SIZE: 2K. The ENV_AREA_SIZE you can define for the different modes are:
  *       1.Normal mode: 1*EF_ERASE_MIN_SIZE
  *       2.Wear leveling mode: 3*EF_ERASE_MIN_SIZE (It has 2 data section to store ENV. So ENV can erase at least 200,000 times)
  *       3.Power fail safeguard mode: 2*EF_ERASE_MIN_SIZE

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -37,13 +37,13 @@
 /**
  * ENV area has 2 sections
  * 1. System section
- *    It storage ENV parameters. (Units: Word)
+ *    It storages ENV parameters. (Units: Word)
  * 2. Data section
- *    It storage all ENV. Storage format is key=value\0.
+ *    It storages all ENV. Storage format is key=value\0.
  *    All ENV must be 4 bytes alignment. The remaining part must fill '\0'.
  *
  * @note Word = 4 Bytes in this file
- * @note It will has two ENV areas(Area0, Area1) when used power fail safeguard mode.
+ * @note When using power fail safeguard mode, it has two ENV areas(Area0, Area1).
  */
 
 /* flash ENV parameters index and size in system section */

--- a/easyflash/src/ef_log.c
+++ b/easyflash/src/ef_log.c
@@ -32,7 +32,7 @@
 
 /* magic code on every sector header. 'EF' is 0x4546 */
 #define LOG_SECTOR_MAGIC               0x4546
-/* sector header size, include the sector magic code and status magic code */
+/* sector header size, includes the sector magic code and status magic code */
 #define LOG_SECTOR_HEADER_SIZE         4
 
 /**
@@ -62,7 +62,7 @@ typedef enum {
     SECTOR_STATUS_HEADER_ERROR,
 } SectorStatus;
 
-/* the stored logs start address and end address. It's like a ring buffer which implement by flash. */
+/* the stored logs start address and end address. It's like a ring buffer implemented on flash. */
 static uint32_t log_start_addr = 0, log_end_addr = 0;
 /* saved log area address for flash */
 static uint32_t log_area_start_addr = 0;
@@ -228,8 +228,8 @@ static uint32_t find_sec_using_end_addr(uint32_t addr) {
 
 /**
  * Find the log store start address and end address.
- * It's like a ring buffer which implement by flash.
- * The flash log area has two state when find start address and end address.
+ * It's like a ring buffer implemented on flash.
+ * The flash log area can be in two states depending on start address and end address:
  *                       state 1                                state 2
  *                   |============|                         |============|
  * log area start--> |############| <-- start address       |############| <-- end address


### PR DESCRIPTION
I've been trying to port the library and I found typos in the documentation which I've fixed in this commit.