### PR TITLE
Fix warnings and add new error code

### DIFF
--- a/easyflash/inc/easyflash.h
+++ b/easyflash/inc/easyflash.h
@@ -78,6 +78,7 @@ typedef struct _ef_env{
 typedef enum {
     EF_NO_ERR,
     EF_ERASE_ERR,
+    EF_READ_ERR,
     EF_WRITE_ERR,
     EF_ENV_NAME_ERR,
     EF_ENV_NAME_EXIST,

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -337,7 +337,7 @@ static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
     size_t key_len = strlen(key), env_len;
 
-    if (*key == NULL) {
+    if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
         return NULL;
     }
@@ -386,7 +386,7 @@ static EfErrCode create_env(const char *key, const char *value) {
     EF_ASSERT(key);
     EF_ASSERT(value);
 
-    if (*key == NULL) {
+    if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
         return EF_ENV_NAME_ERR;
     }
@@ -421,7 +421,7 @@ static EfErrCode del_env(const char *key){
 
     EF_ASSERT(key);
 
-    if (*key == NULL) {
+    if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not NULL!\n");
         return EF_ENV_NAME_ERR;
     }
@@ -480,7 +480,7 @@ EfErrCode ef_set_env(const char *key, const char *value) {
     ef_port_env_lock();
 
     /* if ENV value is empty, delete it */
-    if (*value == NULL) {
+    if ((value == NULL) || *value == '\0') {
         result = del_env(key);
     } else {
         old_env = find_env(key);
@@ -554,7 +554,7 @@ void ef_print_env(void) {
         for (j = 0; j < 4; j++) {
             c = (*env_cache_data_addr) >> (8 * j);
             ef_print("%c", c);
-            if (c == NULL) {
+            if (c == '\0') {
                 ef_print("\n");
                 break;
             }

--- a/easyflash/src/ef_env_wl.c
+++ b/easyflash/src/ef_env_wl.c
@@ -354,7 +354,7 @@ static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
     size_t key_len = strlen(key), env_len;
 
-    if (*key == NULL) {
+    if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
         return NULL;
     }
@@ -404,7 +404,7 @@ static EfErrCode create_env(const char *key, const char *value) {
     EF_ASSERT(key);
     EF_ASSERT(value);
 
-    if (*key == NULL) {
+    if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
         return EF_ENV_NAME_ERR;
     }
@@ -439,7 +439,7 @@ static EfErrCode del_env(const char *key) {
 
     EF_ASSERT(key);
 
-    if (*key == NULL) {
+    if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not NULL!\n");
         return EF_ENV_NAME_ERR;
     }
@@ -498,7 +498,7 @@ EfErrCode ef_set_env(const char *key, const char *value) {
     ef_port_env_lock();
 
     /* if ENV value is empty, delete it */
-    if (*value == NULL) {
+    if ((value == NULL) || (*value == '\0')) {
         result = del_env(key);
     } else {
         old_env = find_env(key);


### PR DESCRIPTION
The first commit avoids the comparison of a pointer with an integer. This causes a warning in the compiler and actually it doesn't make much sense:

```c
char value[5];
if (*value == NULL) {} // This is incorrect
```

This code is typically used to find an empty string, so I've replaced it by the next snippet, which checks both if the pointer is NULL or the string is empty.

```c
if ((value == NULL) || *value == '\0') { 
```

The second one adds a new error code (`EF_READ_ERR`) which I use in `ef_port_read()`. I think it makes sense to have it since there is one for the rest of the functions.

Sorry, I probably should have opened two different PRs...