### PR TITLE
【修复】没有开启 EF_ENV_AUTO_UPDATE 时的编译警告（MDK）

### DIFF
--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -101,7 +101,9 @@ static size_t get_env_user_used_size(void);
 static EfErrCode create_env(const char *key, const char *value);
 static uint32_t calc_env_crc(void);
 static bool env_crc_is_ok(void);
+#ifdef EF_ENV_AUTO_UPDATE
 static EfErrCode env_auto_update(void);
+#endif
 
 /**
  * Flash ENV initialize.


### PR DESCRIPTION
【修复】没有开启 EF_ENV_AUTO_UPDATE 时的编译警告（MDK）

Signed-off-by: MurphyZhao <d2014zjt@163.com>