### PR TITLE
【修复】没有开启 EF_ENV_AUTO_UPDATE 时的编译警告（MDK）

### DIFF
--- a/easyflash/src/ef_env_wl.c
+++ b/easyflash/src/ef_env_wl.c
@@ -113,7 +113,9 @@ static EfErrCode del_env(const char *key);
 static EfErrCode save_cur_using_data_addr(uint32_t cur_data_addr);
 static uint32_t calc_env_crc(void);
 static bool env_crc_is_ok(void);
+#ifdef EF_ENV_AUTO_UPDATE
 static EfErrCode env_auto_update(void);
+#endif
 
 /**
  * Flash ENV initialize.


### PR DESCRIPTION
【修复】没有开启 EF_ENV_AUTO_UPDATE 时的编译警告（MDK）

Signed-off-by: MurphyZhao <d2014zjt@163.com>