### PR TITLE
sector_magic变量是上个版本的，该版本应该使用sector_header_magic，否则编译报错。

### DIFF
--- a/easyflash/src/ef_log.c
+++ b/easyflash/src/ef_log.c
@@ -132,7 +132,7 @@ static SectorStatus get_sector_status(uint32_t addr) {
     }
 
     /* compare header magic code */
-    if(sector_magic == LOG_SECTOR_MAGIC){
+    if(sector_header_magic == LOG_SECTOR_MAGIC){
         if((status_use_magic == SECTOR_STATUS_MAGIC_EMPUT) && (status_full_magic == SECTOR_STATUS_MAGIC_EMPUT)) {
             return SECTOR_STATUS_EMPUT;
         } else if((status_use_magic == SECTOR_STATUS_MAGIC_USING) && (status_full_magic == SECTOR_STATUS_MAGIC_EMPUT)) {


### PR DESCRIPTION
ef_log.c中sector_magic变量是上个V3.2.3版本的，该版本V3.2.4应该使用sector_header_magic，否则编译报错。

已经亲自测试过，这么改后符合作者的修改意图。