### PR TITLE
fix warning in cJson

### DIFF
--- a/easyflash/plugins/types/struct2json/src/cJSON.c
+++ b/easyflash/plugins/types/struct2json/src/cJSON.c
@@ -276,27 +276,8 @@ static char *print_string_ptr(const char *str,printbuffer *p)
 		strcpy(out,"\"\"");
 		return out;
 	}
-    
-	ptr=str;
-#if 0
-    while ((token=*ptr) && ++len) 
-    {
-        if (strchr("\"\\\b\f\n\r\t",token)) 
-            len++; 
-        else if (token<32) 
-            len+=5;
-        ptr++;
-    }
-#else
-    do {
-        token=*ptr;
-        if (strchr("\"\\\b\f\n\r\t",token)) 
-            len++; 
-        else if (token<32) 
-            len+=5;
-        ptr++;
-    } while (token && ++len);
-#endif	
+	ptr=str;while ((token=*ptr) && ++len) {if (strchr("\"\\\b\f\n\r\t",token)) len++; else if (token<32) len+=5;ptr++;}
+	
 	if (p)	out=ensure(p,len+3);
 	else	out=(char*)cJSON_malloc(len+3);
 	if (!out) return 0;

--- a/easyflash/plugins/types/struct2json/src/cJSON.c
+++ b/easyflash/plugins/types/struct2json/src/cJSON.c
@@ -52,7 +52,7 @@ static char* cJSON_strdup(const char* str)
       char* copy;
 
       len = strlen(str) + 1;
-      if (!(copy = (char*)cJSON_malloc(len))) return 0;
+      if ((copy = (char*)cJSON_malloc(len)) == NULL) return 0;
       memcpy(copy,str,len);
       return copy;
 }
@@ -276,8 +276,27 @@ static char *print_string_ptr(const char *str,printbuffer *p)
 		strcpy(out,"\"\"");
 		return out;
 	}
-	ptr=str;while ((token=*ptr) && ++len) {if (strchr("\"\\\b\f\n\r\t",token)) len++; else if (token<32) len+=5;ptr++;}
-	
+    
+	ptr=str;
+#if 0
+    while ((token=*ptr) && ++len) 
+    {
+        if (strchr("\"\\\b\f\n\r\t",token)) 
+            len++; 
+        else if (token<32) 
+            len+=5;
+        ptr++;
+    }
+#else
+    do {
+        token=*ptr;
+        if (strchr("\"\\\b\f\n\r\t",token)) 
+            len++; 
+        else if (token<32) 
+            len+=5;
+        ptr++;
+    } while (token && ++len);
+#endif	
 	if (p)	out=ensure(p,len+3);
 	else	out=(char*)cJSON_malloc(len+3);
 	if (!out) return 0;
@@ -350,7 +369,7 @@ char *cJSON_PrintBuffered(cJSON *item,int prebuffer,int fmt)
 	p.length=prebuffer;
 	p.offset=0;
 	return print_value(item,0,fmt,&p);
-	return p.buffer;
+	//return p.buffer;
 }
 
 
@@ -421,7 +440,7 @@ static const char *parse_array(cJSON *item,const char *value)
 	while (*value==',')
 	{
 		cJSON *new_item;
-		if (!(new_item=cJSON_New_Item())) return 0; 	/* memory fail */
+		if ((new_item=cJSON_New_Item()) == NULL) return 0; 	/* memory fail */
 		child->next=new_item;new_item->prev=child;child=new_item;
 		value=skip(parse_value(child,skip(value+1)));
 		if (!value) return 0;	/* memory fail */
@@ -533,7 +552,7 @@ static const char *parse_object(cJSON *item,const char *value)
 	while (*value==',')
 	{
 		cJSON *new_item;
-		if (!(new_item=cJSON_New_Item()))	return 0; /* memory fail */
+		if ((new_item=cJSON_New_Item()) == NULL)	return 0; /* memory fail */
 		child->next=new_item;new_item->prev=child;child=new_item;
 		value=skip(parse_string(child,skip(value+1)));
 		if (!value) return 0;

--- a/easyflash/src/ef_log.c
+++ b/easyflash/src/ef_log.c
@@ -124,7 +124,7 @@ static SectorStatus get_sector_status(uint32_t addr) {
     uint32_t status_full_magic = 0, status_use_magic = 0;
 
     /* calculate the sector header address */
-    header_addr = addr / EF_ERASE_MIN_SIZE * EF_ERASE_MIN_SIZE;
+    header_addr = addr & (~(EF_ERASE_MIN_SIZE - 1));
 
     if (ef_port_read(header_addr, header_buf, sizeof(header_buf)) == EF_NO_ERR) {
         sector_header_magic = header_buf[SECTOR_HEADER_MAGIC_INDEX];
@@ -164,7 +164,7 @@ static EfErrCode write_sector_status(uint32_t addr, SectorStatus status) {
     uint32_t header, header_addr = 0;
 
     /* calculate the sector header address */
-    header_addr = addr / EF_ERASE_MIN_SIZE * EF_ERASE_MIN_SIZE;
+    header_addr = addr & (~(EF_ERASE_MIN_SIZE - 1));
 
     /* calculate the sector staus magic */
     switch (status) {


### PR DESCRIPTION
原来在C99，MDK下编译产生5个warning
warning:  #1293-D: assignment in condition
解决了4个，有一个没能力解决
ptr=str;while ((token=*ptr) && ++len) {if (strchr("\"\\\b\f\n\r\t",token)) len++; else if (token<32) len+=5;ptr++;}
另外，在lef_og.c中存在
header_addr = addr / EF_ERASE_MIN_SIZE * EF_ERASE_MIN_SIZE;
这个语句在MDK环境开O3后可能会出现被优化