### PR TITLE
针对ENV添加大小端MCU的适配

### DIFF
--- a/easyflash/inc/ef_cfg.h
+++ b/easyflash/inc/ef_cfg.h
@@ -40,8 +40,9 @@
  * Please change it when your firmware add a new ENV to default_env_set.
  */
 #define EF_ENV_VER_NUM            /* @note you must define it for a value, such as 0 */
-
-#define EF_LITTLE_ENDIAN             1     /* @note you must define it reference to MCU Order*/
+ 
+/* MCU Endian Configuration, default is Little Endian Order.
+/* #define EF_BIG_ENDIAN  */         
 
 #endif /* EF_USING_ENV */
 

--- a/easyflash/inc/ef_cfg.h
+++ b/easyflash/inc/ef_cfg.h
@@ -41,7 +41,7 @@
  */
 #define EF_ENV_VER_NUM            /* @note you must define it for a value, such as 0 */
 
-#define LITTLE_ENDIAN             1     /* @note you must define it reference to MCU Order*/
+#define EF_LITTLE_ENDIAN             1     /* @note you must define it reference to MCU Order*/
 
 #endif /* EF_USING_ENV */
 

--- a/easyflash/inc/ef_cfg.h
+++ b/easyflash/inc/ef_cfg.h
@@ -40,6 +40,9 @@
  * Please change it when your firmware add a new ENV to default_env_set.
  */
 #define EF_ENV_VER_NUM            /* @note you must define it for a value, such as 0 */
+
+#define LITTLE_ENDIAN             1     /* @note you must define it reference to MCU Order*/
+
 #endif /* EF_USING_ENV */
 
 /* using IAP function */

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -495,7 +495,11 @@ static uint32_t find_next_env_addr(uint32_t start, uint32_t end)
     for (; start < end; start += (sizeof(buf) - sizeof(uint32_t))) {
         ef_port_read(start, (uint32_t *) buf, sizeof(buf));
         for (i = 0; i < sizeof(buf) - sizeof(uint32_t) && start + i < end; i++) {
+#if LITTLE_ENDIAN            // Little Endian Order
             magic = buf[i] + (buf[i + 1] << 8) + (buf[i + 2] << 16) + (buf[i + 3] << 24);
+#else                       // Big Endian Order
+            magic = buf[i + 3] + (buf[i + 2] << 8) + (buf[i + 1] << 16) + (buf[i] << 24);
+#endif
             if (magic == ENV_MAGIC_WORD && (start + i - ENV_MAGIC_OFFSET) >= start_bak) {
                 return start + i - ENV_MAGIC_OFFSET;
             }

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -495,7 +495,7 @@ static uint32_t find_next_env_addr(uint32_t start, uint32_t end)
     for (; start < end; start += (sizeof(buf) - sizeof(uint32_t))) {
         ef_port_read(start, (uint32_t *) buf, sizeof(buf));
         for (i = 0; i < sizeof(buf) - sizeof(uint32_t) && start + i < end; i++) {
-#if EF_LITTLE_ENDIAN            // Little Endian Order
+#ifndef EF_BIG_ENDIAN            /* Little Endian Order */
             magic = buf[i] + (buf[i + 1] << 8) + (buf[i + 2] << 16) + (buf[i + 3] << 24);
 #else                       // Big Endian Order
             magic = buf[i + 3] + (buf[i + 2] << 8) + (buf[i + 1] << 16) + (buf[i] << 24);

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -495,7 +495,7 @@ static uint32_t find_next_env_addr(uint32_t start, uint32_t end)
     for (; start < end; start += (sizeof(buf) - sizeof(uint32_t))) {
         ef_port_read(start, (uint32_t *) buf, sizeof(buf));
         for (i = 0; i < sizeof(buf) - sizeof(uint32_t) && start + i < end; i++) {
-#if LITTLE_ENDIAN            // Little Endian Order
+#if EF_LITTLE_ENDIAN            // Little Endian Order
             magic = buf[i] + (buf[i + 1] << 8) + (buf[i + 2] << 16) + (buf[i + 3] << 24);
 #else                       // Big Endian Order
             magic = buf[i + 3] + (buf[i + 2] << 8) + (buf[i + 1] << 16) + (buf[i] << 24);


### PR DESCRIPTION
由于大小端MCU的数据存储格式不同，导致MagicNumber获取的数据出现错误，为此添加适配代码

```c
#if EF_LITTLE_ENDIAN            // Little Endian Order
            magic = buf[i] + (buf[i + 1] << 8) + (buf[i + 2] << 16) + (buf[i + 3] << 24);
#else                       // Big Endian Order
            magic = buf[i + 3] + (buf[i + 2] << 8) + (buf[i + 1] << 16) + (buf[i] << 24);
#endif
```