### PR TITLE
修正了 find_env_cb() 函数中的一处判断 key 是否相等错误的 bug

### DIFF
--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -713,6 +713,10 @@ static bool find_env_cb(env_node_obj_t env, void *arg1, void *arg2)
     bool *find_ok = arg2;
     uint8_t max_len = strlen(key);
 
+    if (max_len != env->name_len) {
+        return false;
+    }
+
     if (max_len < env->name_len) {
         max_len = env->name_len;
     }

--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -711,17 +711,13 @@ static bool find_env_cb(env_node_obj_t env, void *arg1, void *arg2)
 {
     const char *key = arg1;
     bool *find_ok = arg2;
-    uint8_t max_len = strlen(key);
+    size_t key_len = strlen(key);
 
-    if (max_len != env->name_len) {
+    if (key_len != env->name_len) {
         return false;
     }
-
-    if (max_len < env->name_len) {
-        max_len = env->name_len;
-    }
     /* check ENV */
-    if (env->crc_is_ok && env->status == ENV_WRITE && !strncmp(env->name, key, max_len)) {
+    if (env->crc_is_ok && env->status == ENV_WRITE && !strncmp(env->name, key, key_len)) {
         *find_ok = true;
         return true;
     }


### PR DESCRIPTION
当 env->name 中 env->name_len 长度后含有垃圾数据时，由于调用的是字符串比较函数，且指定的 max_len 错误，
该 bug 会导致超出 env->name_len 长度但在 strlen(key) 长度内的垃圾数据也会参与比较，如果相等则认为找到了需要查找的 key.
实际需要避免这些垃圾数据影响实际 key 值的比较。