### PR TITLE
修正了 del_env() 函数中的一处未判断 key 是否为 NULL 的 bug

### DIFF
--- a/easyflash/src/ef_env.c
+++ b/easyflash/src/ef_env.c
@@ -1095,8 +1095,14 @@ static EfErrCode del_env(const char *key, env_node_obj_t old_env, bool complete_
 
         if (!last_is_complete_del && result == EF_NO_ERR) {
 #ifdef EF_ENV_USING_CACHE
-            /* only delete the ENV in flash and cache when only using del_env(key, env, true) in ef_del_env() */
-            update_env_cache(key, strlen(key), FAILED_ADDR);
+            /* delete the ENV in flash and cache */
+            if (key != NULL) {
+                /* when using del_env(key, NULL, true) or del_env(key, env, true) in ef_del_env() and set_env() */
+                update_env_cache(key, strlen(key), FAILED_ADDR);
+            } else if (old_env != NULL) {
+                /* when using del_env(NULL, env, true) in move_env() */
+                update_env_cache(old_env->name, old_env->name_len, FAILED_ADDR);
+            }
 #endif /* EF_ENV_USING_CACHE */
         }
 


### PR DESCRIPTION
move_env() 中末尾处在调用 del_env() 时会使用 del_env(NULL, env, true),
此时 key 为 NULL, 需使用 old_env 中的 name 和 name_len