### PR TITLE
[修复]注释符不匹配

### DIFF
--- a/easyflash/inc/ef_cfg.h
+++ b/easyflash/inc/ef_cfg.h
@@ -41,7 +41,7 @@
  */
 #define EF_ENV_VER_NUM            /* @note you must define it for a value, such as 0 */
  
-/* MCU Endian Configuration, default is Little Endian Order.
+/* MCU Endian Configuration, default is Little Endian Order. */
 /* #define EF_BIG_ENDIAN  */         
 
 #endif /* EF_USING_ENV */


### PR DESCRIPTION
大佬，丢了一个注释符：
![image](https://user-images.githubusercontent.com/30443637/79825619-1a896380-83cc-11ea-91e4-878f03c4cfb8.png)
